### PR TITLE
SDT-65: Added workflow for publishing Swagger specs

### DIFF
--- a/.github/workflows/swagger.yml
+++ b/.github/workflows/swagger.yml
@@ -1,0 +1,38 @@
+name: Publish Swagger Specs
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle-
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Run Swagger Publisher
+        run: ./gradlew integration --tests uk.gov.hmcts.reform.civil.config.SwaggerPublisherTest
+      - name: Commit to repository
+        run: |
+          mkdir swagger-staging
+          cd swagger-staging
+          git init
+          git config user.email "github-actions@users.noreply.github.com"
+          git config user.name "Civil SDT Gateway GitHub action"
+          git remote add upstream https://${{ secrets.SWAGGER_PUBLISHER_API_TOKEN }}@github.com/hmcts/reform-api-docs.git
+          git pull upstream master
+          repo=`echo "$GITHUB_REPOSITORY" | cut -f2- -d/`
+          echo "$(cat /tmp/swagger-specs.json)" > "docs/specs/$repo.json"
+          git add "docs/specs/$repo.json"
+          # Only commit and push if we have changes.
+          git diff --quiet && git diff --staged --quiet || (git commit -m "Update spec for $repo#${GITHUB_SHA:7}"; git push --set-upstream upstream master)


### PR DESCRIPTION
### JIRA link (if applicable) ###
SDT-65 (https://tools.hmcts.net/jira/browse/SDT-65)


### Change description ###
Added GitHub workflow file for publishing civil-sdt-gateway Swagger specs


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
