### PR TITLE
SDT-65: Updated Template CI GitHub actions versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v2
+      - uses: actions/checkout@v3.1.0
+      - uses: actions/setup-java@v3.6.0
         with:
           distribution: 'temurin' # See 'Supported distributions' for available options
           java-version: '11'


### PR DESCRIPTION
### JIRA link (if applicable) ###
SDT-65 (https://tools.hmcts.net/jira/browse/SDT-65)


### Change description ###
Updated versions of GitHub actions/checkout and actions/setup-java dependencies in Template CI workflow.  This was done to resolve warnings about the use of deprecated actions commands and Node.js 12.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
