### PR TITLE
SDT-65: Updated Swagger Specs GitHub actions versions

### DIFF
--- a/.github/workflows/swagger.yml
+++ b/.github/workflows/swagger.yml
@@ -9,15 +9,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3.1.0
       - name: Set up Cache
-        uses: actions/cache@v1
+        uses: actions/cache@v3.0.11
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: ${{ runner.os }}-gradle-
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3.6.0
         with:
           java-version: 11
       - name: Run Swagger Publisher


### PR DESCRIPTION
### JIRA link (if applicable) ###
SDT-65 (https://tools.hmcts.net/jira/browse/SDT-65)


### Change description ###
Updated versions of GitHub actions/checkout, actions/cache and actions/setup-java dependencies in Publish Swagger Specs workflow.  This was done to resolve warnings about the use of deprecated actions commands and Node.js 12.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
