### PR TITLE
SDT-65: Updated Swagger Specs GitHub actions versions

### DIFF
--- a/.github/workflows/swagger.yml
+++ b/.github/workflows/swagger.yml
@@ -19,7 +19,9 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v3.6.0
         with:
+          distribution: 'temurin' # See 'Supported distributions' for available options
           java-version: 11
+          cache: 'gradle'
       - name: Run Swagger Publisher
         run: ./gradlew integration --tests uk.gov.hmcts.reform.civil.config.SwaggerPublisherTest
       - name: Commit to repository


### PR DESCRIPTION
### JIRA link (if applicable) ###
SDT-65 (https://tools.hmcts.net/jira/browse/SDT-65)


### Change description ###
Added distribution and cache properties for actions/setup-java.  The distribution property is now a required property.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
